### PR TITLE
fix: solving function name problem updating to a valid one by formatt…

### DIFF
--- a/agentle/agents/apis/endpoint.py
+++ b/agentle/agents/apis/endpoint.py
@@ -592,9 +592,11 @@ class Endpoint(BaseModel):
 
                 tool_parameters[param.name] = param_info
 
+        tool_name = "_".join(self.name.lower().split())
+
         # Create the tool
         tool = Tool(
-            name=self.name,
+            name=tool_name,
             description=self.get_enhanced_description(),
             parameters=tool_parameters,
         )


### PR DESCRIPTION
## **Versão Curta (Alternativa)**

```markdown
**fix: padroniza geração de tool_name com snake_case**

Corrige a geração de `tool_name` para usar snake_case consistente, convertendo espaços para underscores e mantendo tudo em minúsculas.

**Antes:** `"My Tool Name"` → `"My Tool Name"`  
**Depois:** `"My Tool Name"` → `"my_tool_name"`

**Testes realizados:** nomes com espaços, maiúsculas, múltiplos espaços.